### PR TITLE
Laravel 11 compatibility

### DIFF
--- a/.github/workflows/laravel-test.yml
+++ b/.github/workflows/laravel-test.yml
@@ -16,10 +16,14 @@ jobs:
       fail-fast: true
       matrix:
         php: [ 8.0, 8.1, 8.2, 8.3 ]
-        laravel: [ 8, 9, 10 ]
+        laravel: [ 8, 9, 10, 11 ]
         exclude:
           - php: 8.0
             laravel: 10
+          - php: 8.0
+            laravel: 11
+          - php: 8.1
+            laravel: 11
 
     services:
       mysql:

--- a/composer.json
+++ b/composer.json
@@ -3,13 +3,13 @@
     "description": "Zero downtime migrations with Laravel and percona toolkit",
     "require": {
         "php": ">=8.0",
-        "illuminate/database": "^8.0|^9.0|^10.0",
-        "illuminate/support": "^8.0|^9.0|^10.0",
-        "symfony/console": "^5.0|^6.0",
-        "symfony/process": "^5.0|^6.0"
+        "illuminate/database": "^8.0|^9.0|^10.0|^11.0",
+        "illuminate/support": "^8.0|^9.0|^10.0|^11.0",
+        "symfony/console": "^5.0|^6.0|^7.0",
+        "symfony/process": "^5.0|^6.0|^7.0"
     },
     "require-dev": {
-        "orchestra/testbench": "6.*|7.*|8.*",
+        "orchestra/testbench": "6.*|7.*|8.*|9.*",
         "phpunit/phpunit": "^8.4|^9.5|^10.0",
         "squizlabs/php_codesniffer": "^3.3"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ffb4c3a93cd30c910fefb61eb3f045f3",
+    "content-hash": "59d2bced7a7d0a8118309b835fc266eb",
     "packages": [
         {
             "name": "brick/math",
@@ -2374,23 +2374,24 @@
         },
         {
             "name": "symfony/console",
-            "version": "v6.0.19",
+            "version": "v6.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "c3ebc83d031b71c39da318ca8b7a07ecc67507ed"
+                "reference": "6edb5363ec0c78ad4d48c5128ebf4d083d89d3a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/c3ebc83d031b71c39da318ca8b7a07ecc67507ed",
-                "reference": "c3ebc83d031b71c39da318ca8b7a07ecc67507ed",
+                "url": "https://api.github.com/repos/symfony/console/zipball/6edb5363ec0c78ad4d48c5128ebf4d083d89d3a9",
+                "reference": "6edb5363ec0c78ad4d48c5128ebf4d083d89d3a9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/polyfill-mbstring": "~1.0",
-                "symfony/service-contracts": "^1.1|^2|^3",
-                "symfony/string": "^5.4|^6.0"
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/string": "^5.4|^6.0|^7.0"
             },
             "conflict": {
                 "symfony/dependency-injection": "<5.4",
@@ -2404,18 +2405,16 @@
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^5.4|^6.0",
-                "symfony/dependency-injection": "^5.4|^6.0",
-                "symfony/event-dispatcher": "^5.4|^6.0",
-                "symfony/lock": "^5.4|^6.0",
-                "symfony/process": "^5.4|^6.0",
-                "symfony/var-dumper": "^5.4|^6.0"
-            },
-            "suggest": {
-                "psr/log": "For using the console logger",
-                "symfony/event-dispatcher": "",
-                "symfony/lock": "",
-                "symfony/process": ""
+                "symfony/config": "^5.4|^6.0|^7.0",
+                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
+                "symfony/event-dispatcher": "^5.4|^6.0|^7.0",
+                "symfony/http-foundation": "^6.4|^7.0",
+                "symfony/http-kernel": "^6.4|^7.0",
+                "symfony/lock": "^5.4|^6.0|^7.0",
+                "symfony/messenger": "^5.4|^6.0|^7.0",
+                "symfony/process": "^5.4|^6.0|^7.0",
+                "symfony/stopwatch": "^5.4|^6.0|^7.0",
+                "symfony/var-dumper": "^5.4|^6.0|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -2444,12 +2443,12 @@
             "homepage": "https://symfony.com",
             "keywords": [
                 "cli",
-                "command line",
+                "command-line",
                 "console",
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.0.19"
+                "source": "https://github.com/symfony/console/tree/v6.4.9"
             },
             "funding": [
                 {
@@ -2465,7 +2464,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:36:10+00:00"
+            "time": "2024-06-28T09:49:33+00:00"
         },
         {
             "name": "symfony/css-selector",
@@ -3972,20 +3971,20 @@
         },
         {
             "name": "symfony/process",
-            "version": "v6.0.19",
+            "version": "v6.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "2114fd60f26a296cc403a7939ab91478475a33d4"
+                "reference": "8d92dd79149f29e89ee0f480254db595f6a6a2c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/2114fd60f26a296cc403a7939ab91478475a33d4",
-                "reference": "2114fd60f26a296cc403a7939ab91478475a33d4",
+                "url": "https://api.github.com/repos/symfony/process/zipball/8d92dd79149f29e89ee0f480254db595f6a6a2c5",
+                "reference": "8d92dd79149f29e89ee0f480254db595f6a6a2c5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2"
+                "php": ">=8.1"
             },
             "type": "library",
             "autoload": {
@@ -4013,7 +4012,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v6.0.19"
+                "source": "https://github.com/symfony/process/tree/v6.4.8"
             },
             "funding": [
                 {
@@ -4029,7 +4028,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:36:10+00:00"
+            "time": "2024-05-31T14:49:08+00:00"
         },
         {
             "name": "symfony/routing",

--- a/tests/Unit/GhostConnectionTest.php
+++ b/tests/Unit/GhostConnectionTest.php
@@ -25,7 +25,7 @@ class GhostConnectionTest extends TestCase
                     'password' => $password,
                 ],
             ])
-            ->setMethods(['getProcess', 'isPretending'])
+            ->onlyMethods(['getProcess', 'isPretending'])
             ->getMock();
 
         $connection->method('getProcess')->willReturn($process);
@@ -46,7 +46,7 @@ class GhostConnectionTest extends TestCase
     {
         return $this->getMockBuilder(Process::class)
             ->setConstructorArgs([[]])
-            ->setMethods(['stop', 'mustRun'])
+            ->onlyMethods(['stop', 'mustRun'])
             ->getMock();
     }
 }

--- a/tests/Unit/PtOnlineSchemaChangeConnectionTest.php
+++ b/tests/Unit/PtOnlineSchemaChangeConnectionTest.php
@@ -162,7 +162,7 @@ class PtOnlineSchemaChangeConnectionTest extends TestCase
                     'password' => $password,
                 ],
             ])
-            ->setMethods(['getProcess', 'isPretending'])
+            ->onlyMethods(['getProcess', 'isPretending'])
             ->getMock();
 
         $connection->method('getProcess')->willReturn($process);
@@ -183,7 +183,7 @@ class PtOnlineSchemaChangeConnectionTest extends TestCase
     {
         return $this->getMockBuilder(Process::class)
             ->setConstructorArgs([[]])
-            ->setMethods(['stop', 'mustRun'])
+            ->onlyMethods(['stop', 'mustRun'])
             ->getMock();
     }
 
@@ -197,7 +197,7 @@ class PtOnlineSchemaChangeConnectionTest extends TestCase
                 '',
                 $config,
             ])
-            ->setMethods(['runProcess', 'isPretending'])
+            ->onlyMethods(['runProcess', 'isPretending'])
             ->getMock();
     }
 }


### PR DESCRIPTION
The https://github.com/Daursu/laravel-zero-downtime-migration/pull/40 does not include all of the necessary package updates and thus cannot be installed in a Laravel 11 project.

I have also updated the tests which used setMethods to use onlyMethods as setMethods has been deprecated in PHPUnit 10.