### PR TITLE
Laravel 11 compatibility

### DIFF
--- a/.github/workflows/laravel-test.yml
+++ b/.github/workflows/laravel-test.yml
@@ -16,10 +16,14 @@ jobs:
       fail-fast: true
       matrix:
         php: [ 8.0, 8.1, 8.2, 8.3 ]
-        laravel: [ 8, 9, 10 ]
+        laravel: [ 8, 9, 10, 11 ]
         exclude:
           - php: 8.0
             laravel: 10
+          - php: 8.0
+            laravel: 11
+          - php: 8.1
+            laravel: 11
 
     services:
       mysql:

--- a/composer.json
+++ b/composer.json
@@ -3,13 +3,13 @@
     "description": "Zero downtime migrations with Laravel and percona toolkit",
     "require": {
         "php": ">=8.0",
-        "illuminate/database": "^8.0|^9.0|^10.0",
-        "illuminate/support": "^8.0|^9.0|^10.0",
-        "symfony/console": "^5.0|^6.0",
-        "symfony/process": "^5.0|^6.0"
+        "illuminate/database": "^8.0|^9.0|^10.0|^11.0",
+        "illuminate/support": "^8.0|^9.0|^10.0|^11.0",
+        "symfony/console": "^5.0|^6.0|^7.0",
+        "symfony/process": "^5.0|^6.0|^7.0"
     },
     "require-dev": {
-        "orchestra/testbench": "6.*|7.*|8.*",
+        "orchestra/testbench": "6.*|7.*|8.*|9.*",
         "phpunit/phpunit": "^8.4|^9.5|^10.0",
         "squizlabs/php_codesniffer": "^3.3"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ffb4c3a93cd30c910fefb61eb3f045f3",
+    "content-hash": "59d2bced7a7d0a8118309b835fc266eb",
     "packages": [
         {
             "name": "brick/math",

--- a/tests/Unit/GhostConnectionTest.php
+++ b/tests/Unit/GhostConnectionTest.php
@@ -25,7 +25,7 @@ class GhostConnectionTest extends TestCase
                     'password' => $password,
                 ],
             ])
-            ->setMethods(['getProcess', 'isPretending'])
+            ->onlyMethods(['getProcess', 'isPretending'])
             ->getMock();
 
         $connection->method('getProcess')->willReturn($process);
@@ -46,7 +46,7 @@ class GhostConnectionTest extends TestCase
     {
         return $this->getMockBuilder(Process::class)
             ->setConstructorArgs([[]])
-            ->setMethods(['stop', 'mustRun'])
+            ->onlyMethods(['stop', 'mustRun'])
             ->getMock();
     }
 }

--- a/tests/Unit/PtOnlineSchemaChangeConnectionTest.php
+++ b/tests/Unit/PtOnlineSchemaChangeConnectionTest.php
@@ -162,7 +162,7 @@ class PtOnlineSchemaChangeConnectionTest extends TestCase
                     'password' => $password,
                 ],
             ])
-            ->setMethods(['getProcess', 'isPretending'])
+            ->onlyMethods(['getProcess', 'isPretending'])
             ->getMock();
 
         $connection->method('getProcess')->willReturn($process);
@@ -183,7 +183,7 @@ class PtOnlineSchemaChangeConnectionTest extends TestCase
     {
         return $this->getMockBuilder(Process::class)
             ->setConstructorArgs([[]])
-            ->setMethods(['stop', 'mustRun'])
+            ->onlyMethods(['stop', 'mustRun'])
             ->getMock();
     }
 
@@ -197,7 +197,7 @@ class PtOnlineSchemaChangeConnectionTest extends TestCase
                 '',
                 $config,
             ])
-            ->setMethods(['runProcess', 'isPretending'])
+            ->onlyMethods(['runProcess', 'isPretending'])
             ->getMock();
     }
 }


### PR DESCRIPTION
Previous PR had upgraded dependencies which caused the PHP 8.0 checks to fail. This PR includes the commit which downgrades those packages.